### PR TITLE
Show example of private repo credentials

### DIFF
--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -9,6 +9,8 @@ argo-cd:
     extraArgs:
       - --insecure
     config:
+      # If the git repo in which this is defined is private, then you need to create a secret containing the repo
+      # authentication credentials and URL so that when you allow ArgoCD to manage itself it can bootstrap properly.
       repositories: |
         - type: helm
           name: stable
@@ -16,3 +18,17 @@ argo-cd:
         - type: helm
           name: argo-cd
           url: https://argoproj.github.io/argo-helm
+        - type: git
+          url: https://example.com/private/repo.git
+          passwordSecret:
+            name: deployment-git-repo-credentials
+            key: password
+          usernameSecret:
+            name: deployment-git-repo-credentials
+            key: username
+      # Following the guide at https://argoproj.github.io/argo-cd/user-guide/diffing/#system-level-configuration
+      resource.customizations: |
+        admissionregistration.k8s.io/MutatingWebhookConfiguration:
+          ignoreDifferences: |
+            jsonPointers:
+            - /webhooks/0/clientConfig/caBundle


### PR DESCRIPTION
When I followed the instructions in https://www.arthurkoziel.com/setting-up-argocd-with-helm/ my ArgoCD root application stopped working when I added the ArgoCD application to itself to manage (via the "root" app structure). The reason is that my deployment repo is private and requires credentials, and manually entered credentials are lost when ArgoCD tries to sync itself after Helm is removed as the manager.

Additionally, although unrelated, a common scenario when deploying applications that define "mutating webhooks" is that ArgoCD shows the app as out-of-sync when it really is not. The resource.customizations field I added here ignores the persistent caBundle difference.